### PR TITLE
Replace omit by making the property optional

### DIFF
--- a/docs/directives/multiroute.md
+++ b/docs/directives/multiroute.md
@@ -15,14 +15,15 @@ Directive for creating Multi-route on the map
 
 ## Inputs
 
-| Name            | Type                            | Default | Required | Description                          |
-| --------------- | ------------------------------- | ------- | -------- | ------------------------------------ |
-| referencePoints | [IMultiRouteReferencePoint]\[]  |         | yes      | Reference points for the multi-route |
-| model           | { params: [IMultiRouteParams] } |         | no       | Params for the multiroute            |
-| options         | [MultiRouteOptions]             |         | no       | Options for the multiroute           |
+| Name            | Type                                       | Default | Required | Description                          |
+| --------------- | ------------------------------------------ | ------- | -------- | ------------------------------------ |
+| referencePoints | [IMultiRouteReferencePoint]\[]             |         | yes      | Reference points for the multi-route |
+| model           | [MultiRouteModel] \| [MultiRouteModelJson] |         | no       | Model for the multiroute             |
+| options         | [MultiRouteOptions]                        |         | no       | Options for the multiroute           |
 
 [imultiroutereferencepoint]: https://tech.yandex.ru/maps/jsapi/doc/2.1/ref/reference/IMultiRouteReferencePoint-docpage/
-[imultirouteparams]: https://yandex.ru/dev/maps/jsapi/doc/2.1/ref/reference/IMultiRouteParams.html/
+[multiroutemodel]: https://yandex.ru/dev/maps/jsapi/doc/2.1/ref/reference/multiRouter.MultiRouteModel.html/
+[multiroutemodeljson]: https://yandex.ru/dev/maps/jsapi/doc/2.1/ref/reference/IMultiRouteModelJson.html/
 [multirouteoptions]: https://tech.yandex.ru/maps/jsapi/doc/2.1/ref/reference/multiRouter.MultiRoute-docpage/#multiRouter.MultiRoute__param-options
 
 ## Outputs

--- a/projects/angular8-yandex-maps/src/lib/directives/ya-multiroute/ya-multiroute.directive.ts
+++ b/projects/angular8-yandex-maps/src/lib/directives/ya-multiroute/ya-multiroute.directive.ts
@@ -11,6 +11,7 @@ import {
 import { Listener } from '../../interfaces/listener';
 import { YaEvent, YaReadyEvent } from '../../interfaces/event';
 import { generateRandomId } from '../../utils/generateRandomId';
+import { Optional } from '../../utils/optional';
 
 /**
  * Directive for creating Multi-route on the map.
@@ -31,8 +32,12 @@ export class YaMultirouteDirective implements OnChanges, OnDestroy {
 
   /**
    * Model description object of a multiroute.
+   * referencePoints input is required so prop can be ignored
    */
-  @Input() public model: { params: ymaps.IMultiRouteParams };
+  @Input() public model: Optional<
+    ymaps.IMultiRouteModelJson,
+    'referencePoints'
+  >;
 
   /**
    * Options for the multiroute.

--- a/projects/angular8-yandex-maps/src/lib/utils/optional.ts
+++ b/projects/angular8-yandex-maps/src/lib/utils/optional.ts
@@ -1,0 +1,1 @@
+export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<T>;


### PR DESCRIPTION
It's revert for https://github.com/ddubrava/angular8-yandex-maps/pull/57 with some additions. The problem that map component also has such shorthands - `zoom`, `center`. So it's necessary to omit the properties there too but I think it's just better to make them optional. They are already optional for map interfaces. Made them optional for multiroute too.