### PR TITLE
refactor: move default version to defaultConfig object

### DIFF
--- a/libs/angular8-yandex-maps/src/lib/services/ya-api-loader/ya-api-loader.service.spec.ts
+++ b/libs/angular8-yandex-maps/src/lib/services/ya-api-loader/ya-api-loader.service.spec.ts
@@ -108,7 +108,7 @@ describe('YaApiLoaderService', () => {
     fireScriptEvents();
   });
 
-  it('should use default language if it is not passed', (done) => {
+  it('should use default config options if they are not passed', (done) => {
     const config: YaConfig = {
       apikey: 'X-X-X',
     };
@@ -116,7 +116,8 @@ describe('YaApiLoaderService', () => {
     mockLoaderService(config);
 
     service.load().subscribe(() => {
-      expect(script.src).toContain('https://api-maps.yandex.ru/2.1');
+      expect(script.src).toContain('https://api-maps.yandex.ru');
+      expect(script.src).toContain('2.1');
       expect(script.src).toContain('apikey=X-X-X');
       expect(script.src).toContain('lang=ru_RU');
       done();
@@ -132,13 +133,14 @@ describe('YaApiLoaderService', () => {
       coordorder: 'latlong',
       load: 'package.full',
       mode: 'release',
-      version: '2.1',
+      version: '2.0',
     };
 
     mockLoaderService(config);
 
     service.load().subscribe(() => {
-      expect(script.src).toContain('https://api-maps.yandex.ru/2.1');
+      expect(script.src).toContain('https://api-maps.yandex.ru');
+      expect(script.src).toContain('2.0');
       expect(script.src).toContain('apikey=X-X-X');
       expect(script.src).toContain('lang=en_US');
       expect(script.src).toContain('coordorder=latlong');

--- a/libs/angular8-yandex-maps/src/lib/services/ya-api-loader/ya-api-loader.service.ts
+++ b/libs/angular8-yandex-maps/src/lib/services/ya-api-loader/ya-api-loader.service.ts
@@ -46,7 +46,10 @@ import { YaApiLoaderCache } from './interfaces/ya-api-loader-cache';
 export class YaApiLoaderService {
   private readonly isBrowser: boolean;
 
-  private readonly defaultConfig: YaConfig = { lang: 'ru_RU' };
+  private readonly defaultConfig: YaConfig = {
+    lang: 'ru_RU',
+    version: '2.1',
+  };
 
   private readonly config$ = new BehaviorSubject<YaConfig>(this.defaultConfig);
 
@@ -166,7 +169,7 @@ export class YaApiLoaderService {
    * getScriptSource({ apikey: '658f67a2-fd77-42e9-b99e-2bd48c4ccad4', lang: 'en_US' })
    */
   private getScriptSource(config: YaConfig): string {
-    const { enterprise, version = '2.1', ...rest } = config;
+    const { enterprise, version, ...rest } = config;
     const params = this.convertConfigIntoQueryParams(rest);
 
     return `https://${enterprise ? 'enterprise.' : ''}api-maps.yandex.ru/${version}/?${params}`;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

We have default options in different places: default value when destructuring and `defaultConfig` object

## What is the new behavior?

All default options are in a `defaultConfig` object

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
