### PR TITLE
feat: throw error if API version is v3

### DIFF
--- a/libs/angular8-yandex-maps/src/lib/services/ya-api-loader/ya-api-loader.service.spec.ts
+++ b/libs/angular8-yandex-maps/src/lib/services/ya-api-loader/ya-api-loader.service.spec.ts
@@ -167,6 +167,23 @@ describe('YaApiLoaderService', () => {
     fireScriptEvents();
   });
 
+  it('should throw error if v3 version is used', (done) => {
+    const config: YaConfig = {
+      version: 'v3',
+    };
+
+    mockLoaderService(config);
+
+    service.load().subscribe({
+      error: (e) => {
+        expect(e).toBeInstanceOf(Error);
+        done();
+      },
+    });
+
+    fireScriptEvents();
+  });
+
   it('should use ymaps from cache if it is defined', (done) => {
     mockLoaderService();
 

--- a/libs/angular8-yandex-maps/src/lib/services/ya-api-loader/ya-api-loader.service.ts
+++ b/libs/angular8-yandex-maps/src/lib/services/ya-api-loader/ya-api-loader.service.ts
@@ -172,6 +172,12 @@ export class YaApiLoaderService {
     const { enterprise, version, ...rest } = config;
     const params = this.convertConfigIntoQueryParams(rest);
 
+    if (version === 'v3') {
+      throw new Error(
+        'Yandex.Maps API v3 is not supported, if you need it like this issue:\nhttps://github.com/ddubrava/angular8-yandex-maps/issues/226',
+      );
+    }
+
     return `https://${enterprise ? 'enterprise.' : ''}api-maps.yandex.ru/${version}/?${params}`;
   }
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

No errors, if someone decides to pass 'v3' everything breaks.

## What is the new behavior?

Now we provide an error that 'v3' is not supported.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
