### PR TITLE
feat: add suggest_apikey & csp to YaConfig (v13)

### DIFF
--- a/projects/angular8-yandex-maps/src/lib/services/ya-api-loader/ya-api-loader.service.ts
+++ b/projects/angular8-yandex-maps/src/lib/services/ya-api-loader/ya-api-loader.service.ts
@@ -13,9 +13,13 @@ export const YA_CONFIG = new InjectionToken<YaConfig>('YA_CONFIG');
  */
 export interface YaConfig {
   /**
-   * API key. You can get a key in the developer's dashboard.
+   * API key.
    */
   apikey?: string;
+  /**
+   * Geosuggest API key.
+   */
+  suggest_apikey?: string;
   /**
    * Locale.
    */
@@ -32,6 +36,10 @@ export interface YaConfig {
    * API loading mode.
    */
   mode?: 'release' | 'debug';
+  /**
+   * Enables CSP mode.
+   */
+  csp?: boolean;
   /**
    * Use commercial version of the API.
    */


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

v13 has an outdated `YaConfig` interface

## What is the new behavior?

`YaConfig` has `suggest_apikey` and `csp` properties.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
