### PR TITLE
feat: add suggest_apikey & csp to YaConfig (v14)

### DIFF
--- a/projects/angular8-yandex-maps/src/lib/models/ya-config.ts
+++ b/projects/angular8-yandex-maps/src/lib/models/ya-config.ts
@@ -3,9 +3,13 @@
  */
 export interface YaConfig {
   /**
-   * API key. You can get a key in the developer's dashboard.
+   * API key.
    */
   apikey?: string;
+  /**
+   * Geosuggest API key.
+   */
+  suggest_apikey?: string;
   /**
    * Locale.
    */
@@ -22,6 +26,10 @@ export interface YaConfig {
    * API loading mode.
    */
   mode?: 'release' | 'debug';
+  /**
+   * Enables CSP mode.
+   */
+  csp?: boolean;
   /**
    * Use commercial version of the API.
    */


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

v14 has an outdated `YaConfig` interface

## What is the new behavior?

`YaConfig` has `suggest_apikey` and `csp` properties.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
